### PR TITLE
Fix example and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
 # elm-identicon
-Generate a GitHub style visual hash from a string (aka identicon).
+Generate a GitHub style visual hash from a string (aka [identicon](https://en.wikipedia.org/wiki/Identicon)).
 
-## Example
+## Examples
 
-See `example/` folder.
+Simple usage: 
+
+``` elm
+identicon "200px" "Hello identicon!"
+```
+
+This will draw a `200px` by `200px` identicon, generated from the `"Hello
+identicon!"` string.
+
+Advanced usage: 
+
+You can customize rendering by bringing your own hasher and/or color functions. For example, the
+following would always draw a red identicon:
+
+``` elm
+import Color exposing (rgb255) -- from avh4/elm-color
+import Identicon
+
+view =
+    Identicon.custom Identicon.defaultHash (always <| rgb255 255 0 0) "200px" "Hello Identicon!"
+```
+
+Also have a look at the
+[`example/`](https://github.com/dividat/elm-identicon/tree/master/example)
+folder for a more detailed use case.

--- a/example/elm.json
+++ b/example/elm.json
@@ -4,7 +4,7 @@
         "src",
         "../src"
     ],
-    "elm-version": "0.19.0 <= v < 0.20.0",
+    "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
             "avh4/elm-color": "1.0.0",

--- a/src/Identicon.elm
+++ b/src/Identicon.elm
@@ -42,9 +42,12 @@ identicon =
 passed into both the hasher and colorer. Here's how to create an identicon
 that's always the color red:
 
-    import Color exposing (rgb255)
+    import Color exposing (rgb255) -- from avh4/elm-color
+    import Identicon exposing (custom, defaultHash)
+    import Html exposing (Html)
 
-    main =
+    view : Html msg
+    view =
         custom defaultHash (always <| rgb255 255 0 0) "200px" "Hello Identicon!"
 
 -}


### PR DESCRIPTION
The PR includes improvements to documentation and example code.
It also reverts https://github.com/dividat/elm-identicon/commit/d6e9d2385eab34c63b940c64c0614a76401980d3, because specifying `elm-version` as a range turns out to be not allowed for applications, only packages.

The following error was thrown by `elm make`:
```
-- BAD JSON ----------------------------------------------------------- elm.json

The string at project['elm-version'] is causing issues.

You provided "0.19.0 <= v < 0.20.0" which is not a valid version. I need
something like "1.0.0" or "2.0.4".
```